### PR TITLE
add a general ObjectIndexableArray type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,33 @@
 
 `TileMaps` is a package that makes it simple to create 2D tile maps in Julia. It is designed to be lightweight and fast, and have minimal dependencies.
 
-**Note:** This package does not export any symbols. The examples below that demonstrate the use of this package assume that it has been loaded via `import TileMaps as TM`.
+**Note:** This package does not export any names. The examples below that demonstrate the use of this package assume that it has been loaded via `import TileMaps as TM`.
 
 **Acknowledgements:** Big thanks to [Jun Tian](https://github.com/findmyway) (@findmyway) for initially introducing the core ideas of this package in [`GridWorlds`](https://github.com/JuliaReinforcementLearning/GridWorlds.jl).
 
 ### Index
 
-1. [TileMap](#tilemap)
+1. [ObjectIndexableArray](#objectindexablearray)
 1. [Objects](#objects)
+1. [TileMap](#tilemap)
 1. [Constructing a TileMap](#constructing-a-tilemap)
 1. [Indexing a TileMap](#indexing-a-tilemap)
 1. [Visualizing a TileMap](#visualizing-a-tilemap)
 
-### TileMap
+
+### `ObjectIndexableArray`
 
 ```
-struct TileMap{O} <: AbstractArray{Bool, 3}
-    grid::BitArray{3}
-    objects::O
+struct ObjectIndexableArray{T, N, A, O} <: AbstractArray{T, N}
+    array::A
 end
 ```
 
-We'll refer to an instance of `TileMap` as `tile_map`. A `tile_map` contains a field called `grid` of type `BitArray{3}` and size `(num_objects, height, width)`, which efficiently stores the objects present in the `tile_map`. Each tile can contain multiple objects, which is captured by a multi-hot encoding along the first dimension (`num_objects` dimension) of the `grid`.
+We'll refer to an instance of `ObjectIndexableArray` as `object_indexable_array`. An `object_indexable_array` simply wraps an `array` and allows us to index its first dimension using a [singleton](https://docs.julialang.org/en/v1/manual/types/#man-singleton-types) object or an array of singleton objects (in addition to all the other ways of indexing `array`).
 
 ### Objects
 
-Objects are [singletons](https://docs.julialang.org/en/v1/manual/types/#man-singleton-types) (structs with no fields). Here is how objects are created inside this package:
+Object types are [singletons](https://docs.julialang.org/en/v1/manual/types/#man-singleton-types) (structs with no fields). Here are the example objects that are provided in this package:
 
 ```
 abstract type AbstractObject end
@@ -50,27 +51,37 @@ julia> struct MyObject <: TM.AbstractObject end
 julia>
 ```
 
+### TileMap
+
+```
+const TileMap{O} = ObjectIndexableArray{Bool, 3, BitArray{3}, O}
+```
+
+We'll refer to an instance of `TileMap` as `tile_map`. A `tile_map` wraps an `array` of size `(num_objects, height, width)`, which encodes information about the presence or absence of objects across the tiles. Each tile can contain multiple objects, which is captured by a multi-hot encoding along the first dimension (`num_objects` dimension) of the `array`.
+
 ### Constructing a `TileMap`
 
-You can instantiate a `TileMap` using a constructor that is provided by this package. The following creates an empty tile map using a tuple of objects along with the desired height and width:
+You can instantiate a `TileMap` using the following constructor that are provided by this package:
+
+1. Create an empty `tile_map` using a tuple of objects and the desired height (8) and width(16):
+
+    ```
+    julia> tile_map = TM.TileMap((TM.EXAMPLE_OBJECT_1, TM.EXAMPLE_OBJECT_2, TM.EXAMPLE_OBJECT_3), 8, 16);
+
+    julia>
+    ```
+
+1. Create a `tile_map` using a tuple of objects and an existing `array`:
 
 ```
-julia> tile_map = TM.TileMap((TM.EXAMPLE_OBJECT_1, TM.EXAMPLE_OBJECT_2, TM.EXAMPLE_OBJECT_3), 8, 16);
-
-julia>
-```
-
-Or you could directly use the default constructor as well:
-
-```
-julia> tile_map = TM.TileMap(rand(Bool, 3, 8, 16) |> BitArray, (TM.EXAMPLE_OBJECT_1, TM.EXAMPLE_OBJECT_2, TM.EXAMPLE_OBJECT_3));
+julia> tile_map = TM.TileMap((TM.EXAMPLE_OBJECT_1, TM.EXAMPLE_OBJECT_2, TM.EXAMPLE_OBJECT_3), rand(Bool, 3, 8, 16) |> BitArray);
 
 julia>
 ```
 
 ### Indexing a `TileMap`
 
-In addition to the normal ways of indexing an array, you can also use an object or an array of objects to index the first dimension of a `tile_map`. For example, something like this:
+Because of `TileMap <: ObjectIndexableArray`, we can index the first dimension of a `tile_map` in a variety of ways. For example, like this:
 
 ```
 julia> tile_map[TM.EXAMPLE_OBJECT_3, 4, 6]
@@ -92,7 +103,7 @@ julia>
 
 ### Visualizing a `TileMap`
 
-Using the [`Crayons`](https://github.com/KristofferC/Crayons.jl) package, each object can be displayed as a colored Unicode character:
+Using the [`Crayons`](https://github.com/KristofferC/Crayons.jl) package, each object can be displayed as a colored Unicode character. For example, like this:
 
 <img src="https://github.com/Sid-Bhatia-0/TileMaps.jl/blob/master/assets/example_object_1.png">
 
@@ -100,7 +111,7 @@ When you create your custom object like this, for example,
 
 <img src="https://github.com/Sid-Bhatia-0/TileMaps.jl/blob/master/assets/my_object.png">
 
-you may also want to implement the following methods: `get_char(::MyObject)` (especially this one), `get_foreground_color(::MyObject)`, and `get_backround_color(::MyObject)`. If you don't do so, it will be displayed based on the following default methods defined in this package:
+you may also want to implement the following methods: `get_char(::MyObject)` (especially this one), `get_foreground_color(::MyObject)`, and `get_backround_color(::MyObject)`. If you don't do so, `MY_OBJECT` will be displayed based on the following default methods as defined in this package:
 
 ```
 get_char(object::Any) = '?'
@@ -108,7 +119,9 @@ get_foreground_color(object::Any) = :white
 get_backround_color(object::Any) = :nothing
 ```
 
-A `tile_map` is displayed as a 2D grid of colored Unicode characters, with one character displayed per tile. Only the first object present at a tile (along the first dimension (`num_objects` dimension) of the `grid`) is displayed for that tile, even though there may be multiple objects present at that tile. If there are no objects present at a tile, then the `⋅` character is displayed for that tile (with white color). This behaviour can be customized by overriding the following methods:
+A `tile_map` is displayed as a 2D grid of colored Unicode characters, with one character displayed per tile. Only the first object present (along the first dimension (`num_objects` dimension) of the `array`) at a tile is displayed for that tile, even though there may be multiple objects present at that tile.
+
+If there are no objects present at a tile, then the `⋅` character is displayed for that tile (with white color and no background). This behaviour can be customized by overriding the following methods:
 
 ```
 get_char(::Nothing) = '⋅'
@@ -118,10 +131,10 @@ get_background_color(::Nothing) = :nothing
 
 <img src="https://github.com/Sid-Bhatia-0/TileMaps.jl/blob/master/assets/tile_map.png">
 
-Note that the `get_char`, `get_foreground_color`, and `get_background_color` methods have purposefully not been defined for the `TM.ExampleObject3` type in order to demonstrate the fallback to the default character and colors, which is why `TM.EXAMPLE_OBJECT_3` is displayed using a white colored `?` with no background.
+Note that the `get_char`, `get_foreground_color`, and `get_background_color` methods have purposefully not been explictly defined for the `TM.ExampleObject3` type in order to demonstrate the fallback to the default character and colors, which is why `TM.EXAMPLE_OBJECT_3` is displayed using a white colored `?` with no background.
 
 We can also inspect each kind of object in the `tile_map` separately using the `show_layers` method. This is very handy for debugging:
 
 <img src="https://github.com/Sid-Bhatia-0/TileMaps.jl/blob/master/assets/show_layers.png">
 
-Here we have used only a limited number of features (foreground and background colors) from the [`Crayons`](https://github.com/KristofferC/Crayons.jl) package for showing an example of how one may want to display a `tile_map`. It has several other features that you can play with to suit your needs.
+Here we have utilized only a limited number of features from the `Crayons` package in order to show an an example of how one may want to display a `tile_map`. `Crayons` has other features that you can play with to suit your needs.

--- a/src/TileMaps.jl
+++ b/src/TileMaps.jl
@@ -3,6 +3,7 @@ module TileMaps
 import Crayons
 
 include("objects.jl")
+include("object_indexable_array.jl")
 include("tile_map.jl")
 include("visualization.jl")
 

--- a/src/object_indexable_array.jl
+++ b/src/object_indexable_array.jl
@@ -2,8 +2,8 @@ struct ObjectIndexableArray{T, N, A, O} <: AbstractArray{T, N}
     array::A
 end
 
-get_object_types(::ObjectIndexableArray{T, N, A, O}) where {T, N, A, O} = O
-get_objects(object_indexable_array::ObjectIndexableArray) = Tuple(object_type() for object_type in get_object_types(object_indexable_array).parameters)
+get_objects_type(::ObjectIndexableArray{T, N, A, O}) where {T, N, A, O} = O
+get_objects(object_indexable_array::ObjectIndexableArray) = Tuple(object_type() for object_type in get_objects_type(object_indexable_array).parameters)
 
 Base.size(object_indexable_array::ObjectIndexableArray, args...; kwargs...) = Base.size(object_indexable_array.array, args..., kwargs...)
 

--- a/src/object_indexable_array.jl
+++ b/src/object_indexable_array.jl
@@ -1,0 +1,25 @@
+struct ObjectIndexableArray{T, N, A, O} <: AbstractArray{T, N}
+    array::A
+end
+
+get_object_types(::ObjectIndexableArray{T, N, A, O}) where {T, N, A, O} = O
+
+Base.size(object_indexable_array::ObjectIndexableArray, args...; kwargs...) = Base.size(object_indexable_array.array, args..., kwargs...)
+
+# regular indexing (indexing without using objects)
+Base.getindex(object_indexable_array::ObjectIndexableArray, args...; kwargs...) = Base.getindex(object_indexable_array.array, args..., kwargs...)
+Base.setindex!(object_indexable_array::ObjectIndexableArray, args...; kwargs...) = Base.setindex!(object_indexable_array.array, args..., kwargs...)
+
+# indexing using a single object as index
+@generated function Base.to_index(object_indexable_array::ObjectIndexableArray{T, N, A, O}, object::X) where {T, N, A, O, X <: AbstractObject}
+    i = findfirst(X .=== O.parameters)
+    isnothing(i) && error("Object $object is not present in $object_indexable_array")
+    return :($i)
+end
+
+Base.getindex(object_indexable_array::ObjectIndexableArray, object::AbstractObject, args...; kwargs...) = getindex(object_indexable_array.array, Base.to_index(object_indexable_array, object), args..., kwargs...)
+Base.setindex!(object_indexable_array::ObjectIndexableArray, value::Bool, object::AbstractObject, args...; kwargs...) = setindex!(object_indexable_array.array, value, Base.to_index(object_indexable_array, object), args..., kwargs...)
+
+# indexing using more than one object
+Base.to_index(object_indexable_array::ObjectIndexableArray, objects::AbstractArray{<:AbstractObject}) = map(object -> Base.to_index(object_indexable_array, object), objects)
+Base.getindex(object_indexable_array::ObjectIndexableArray, objects::AbstractArray{<:AbstractObject}, args...; kwargs...) = getindex(object_indexable_array.array, map(object -> Base.to_index(object_indexable_array, object), objects), args..., kwargs...)

--- a/src/object_indexable_array.jl
+++ b/src/object_indexable_array.jl
@@ -3,6 +3,7 @@ struct ObjectIndexableArray{T, N, A, O} <: AbstractArray{T, N}
 end
 
 get_object_types(::ObjectIndexableArray{T, N, A, O}) where {T, N, A, O} = O
+get_objects(object_indexable_array::ObjectIndexableArray) = Tuple(object_type() for object_type in get_object_types(object_indexable_array).parameters)
 
 Base.size(object_indexable_array::ObjectIndexableArray, args...; kwargs...) = Base.size(object_indexable_array.array, args..., kwargs...)
 

--- a/src/object_occupancy_array.jl
+++ b/src/object_occupancy_array.jl
@@ -1,0 +1,6 @@
+const ObjectOccupancyArray{O, N} = ObjectIndexableArray{O, BitArray{N}, Bool, N}
+
+function ObjectOccupancyArray(objects::Tuple{Vararg{AbstractObject}}, dims::Integer...)
+    grid = falses(length(objects), dims...)
+    return ObjectOccupancyArray{typeof(objects), length(dims) + 1}(grid)
+end

--- a/src/tile_map.jl
+++ b/src/tile_map.jl
@@ -1,37 +1,13 @@
 """
-    TileMap{O} <: AbstractArray{Bool, 3}
 The first dimension uses multi-hot encoding to encode objects in a tile.
 The second and third dimensions correspond to the height and width of the tile map respectively.
 """
-struct TileMap{O} <: AbstractArray{Bool, 3}
-    grid::BitArray{3}
-    objects::O
-end
+const TileMap{O} = ObjectIndexableArray{Bool, 3, BitArray{3}, O}
 
-function TileMap(objects::Tuple{Vararg{AbstractObject}}, height::Integer, width::Integer)
-    grid = falses(length(objects), height, width)
-    return TileMap(grid, objects)
-end
+TileMap(objects::Tuple{Vararg{AbstractObject}}, grid::BitArray{3}) = TileMap{typeof(objects)}(grid)
 
-Base.size(tile_map::TileMap, args...; kwargs...) = Base.size(tile_map.grid, args..., kwargs...)
+TileMap(objects::Tuple{Vararg{AbstractObject}}, height::Integer, width::Integer) = TileMap(objects, falses(length(objects), height, width))
+
 get_num_objects(tile_map::TileMap) = size(tile_map, 1)
 get_height(tile_map::TileMap) = size(tile_map, 2)
 get_width(tile_map::TileMap) = size(tile_map, 3)
-
-# regular indexing (indexing without using objects)
-Base.getindex(tile_map::TileMap, args...; kwargs...) = Base.getindex(tile_map.grid, args..., kwargs...)
-Base.setindex!(tile_map::TileMap, args...; kwargs...) = Base.setindex!(tile_map.grid, args..., kwargs...)
-
-# indexing using one object
-@generated function Base.to_index(tile_map::TileMap{O}, object::X) where {X <: AbstractObject, O}
-    i = findfirst(X .=== O.parameters)
-    isnothing(i) && error("Object $object is not present in $tile_map")
-    return :($i)
-end
-
-Base.getindex(tile_map::TileMap, object::AbstractObject, args...; kwargs...) = getindex(tile_map.grid, Base.to_index(tile_map, object), args..., kwargs...)
-Base.setindex!(tile_map::TileMap, value::Bool, object::AbstractObject, args...; kwargs...) = setindex!(tile_map.grid, value, Base.to_index(tile_map, object), args..., kwargs...)
-
-# indexing using more than one object
-Base.to_index(tile_map::TileMap, objects::AbstractArray{<:AbstractObject}) = map(object -> Base.to_index(tile_map, object), objects)
-Base.getindex(tile_map::TileMap, objects::AbstractArray{<:AbstractObject}, args...; kwargs...) = getindex(tile_map.grid, map(object -> Base.to_index(tile_map, object), objects), args..., kwargs...)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -29,12 +29,12 @@ function Base.show(io::IO, ::MIME"text/plain", object::AbstractObject)
     return nothing
 end
 
-function get_first_object(tile_map::TileMap, height::Integer, width::Integer)
+function get_first_object(tile_map::TileMap{O}, height::Integer, width::Integer) where {O}
     idx = findfirst(tile_map[:, height, width])
     if isnothing(idx)
         return nothing
     else
-        return tile_map.objects[idx]
+        return O.parameters[idx]()
     end
 end
 
@@ -59,8 +59,9 @@ function Base.show(io::IO, ::MIME"text/plain", tile_map::TileMap)
     return nothing
 end
 
-function show_layers(io::IO, ::MIME"text/plain", tile_map::TileMap)
-    for (layer, object) in enumerate(tile_map.objects)
+function show_layers(io::IO, ::MIME"text/plain", tile_map::TileMap{O}) where {O}
+    for (layer, object_type) in enumerate(O.parameters)
+        object = object_type()
         println("layer = $layer, object = $object")
         for i in 1:get_height(tile_map)
             for j in 1:get_width(tile_map)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ Test.@testset "TileMaps.jl" begin
 
     tile_map = TM.TileMap(objects, grid)
 
+    Test.@test TM.get_objects(tile_map) == objects
+
     # regular indexing (indexing without using objects)
     Test.@test tile_map[1, 2, 3] == false
     Test.@test tile_map[1:3, 2, 2] == BitArray([1, 0, 1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ Test.@testset "TileMaps.jl" begin
     grid[2, :, :] .= layer_2
     grid[3, :, :] .= layer_3
 
-    tile_map = TM.TileMap(grid, objects)
+    tile_map = TM.TileMap(objects, grid)
 
     # regular indexing (indexing without using objects)
     Test.@test tile_map[1, 2, 3] == false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,9 +30,9 @@ Test.@testset "TileMaps.jl" begin
     Test.@test TM.get_objects_type(tile_map) == typeof(objects)
     Test.@test TM.get_objects(tile_map) == objects
 
-    Test.@test TM.get_num_objects(tile_map) = 3
-    Test.@test TM.get_height(tile_map) = 4
-    Test.@test TM.get_width(tile_map) = 5
+    Test.@test TM.get_num_objects(tile_map) == 3
+    Test.@test TM.get_height(tile_map) == 4
+    Test.@test TM.get_width(tile_map) == 5
 
     # regular indexing (indexing without using objects)
     Test.@test tile_map[1, 2, 3] == false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,12 @@ Test.@testset "TileMaps.jl" begin
 
     tile_map = TM.TileMap(objects, grid)
 
+    Test.@test TM.get_objects_type(tile_map) == typeof(objects)
     Test.@test TM.get_objects(tile_map) == objects
+
+    Test.@test TM.get_num_objects(tile_map) = 3
+    Test.@test TM.get_height(tile_map) = 4
+    Test.@test TM.get_width(tile_map) = 5
 
     # regular indexing (indexing without using objects)
     Test.@test tile_map[1, 2, 3] == false


### PR DESCRIPTION
1. Add `ObjectIndexableArray` type. It has only one field, `array`. All object related information is already stored in its type and thus we don't need the `objects` field.
2. `TileMap` is derived as a subtype of `ObjectIndexableArray`.
3. Update `visualization.jl` according to the above changes.
3. Update tests.
4. Update `README`.